### PR TITLE
Remove usage of TestFlight SDK

### DIFF
--- a/BarMagnet/AppDelegate.m
+++ b/BarMagnet/AppDelegate.m
@@ -17,10 +17,6 @@
 	
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-#ifndef ANDROID
-	[TestFlight takeOff:@"1d15ef35-8692-4cc4-9d94-96f36bb449b6"];
-#endif
-
 	if ([UIApplication.sharedApplication respondsToSelector:@selector(setMinimumBackgroundFetchInterval:)])
 	{
 		[UIApplication.sharedApplication setMinimumBackgroundFetchInterval:60];

--- a/BarMagnet/BarMagnet-Prefix.pch
+++ b/BarMagnet/BarMagnet-Prefix.pch
@@ -18,8 +18,6 @@
 	#import "NSNumber+TransferRateFormatting.h"
 	#import "NSOption.h"
 	#ifndef ANDROID
-	#import "TestFlight.h"
-	#define NSLog(__FORMAT__, ...) TFLog((@"%s [Line %d] " __FORMAT__), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
 	#endif
 
 


### PR DESCRIPTION
TestFlight SDK remote debugging API is no longer available for new developers -- removing from project. 

Resolves Issue #1 
